### PR TITLE
Сохранение токена авторизации через localStorage

### DIFF
--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -8,5 +8,12 @@ const authSelector = createSelector([userSelector, isAuthSelector], (user, isAut
 }));
 
 export const useAuth = () => {
-  return useAppSelector(authSelector);
+  const storeAuth = useAppSelector(authSelector);
+  const token = localStorage.getItem('token');
+  const isAuthenticated = Boolean(token) || storeAuth.isAuth;
+  return {
+    ...storeAuth,
+    token,
+    isAuthenticated,
+  };
 };

--- a/src/features/auth/ui/LoginForm/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm/LoginForm.tsx
@@ -19,7 +19,8 @@ export const LoginForm: FC = () => {
     { setErrors, setSubmitting }: FormikHelpers<LoginFormValues>
   ) => {
     try {
-      await login(values).unwrap();
+      const response = await login(values).unwrap();
+      localStorage.setItem('token', response.token);
       enqueueSnackbar('Успешный вход!', { variant: 'success' });
       navigateByType('close');
     } catch (error) {


### PR DESCRIPTION
📌 Что сделано:
- Обновлен хук `useAuth` для проверки токена в `localStorage`
- Добавлены свойства `token` и `isAuthenticated` в возвращаемый объект
- Сохранение токена из ответа после успешного логина